### PR TITLE
Ast generation

### DIFF
--- a/src/parser/inc/CuMatVisitor.hpp
+++ b/src/parser/inc/CuMatVisitor.hpp
@@ -25,7 +25,8 @@ class CuMatVisitor : public CuMatParserBaseVisitor {
     antlrcpp::Any visitBlock(CuMatParser::BlockContext* ctx) override;
 
     antlrcpp::Any visitAssignment(CuMatParser::AssignmentContext* ctx) override;
-    antlrcpp::Any visitVarname(CuMatParser::VarnameContext* ctx) override;
+    antlrcpp::Any visitDecomp(CuMatParser::DecompContext* ctx) override;
+    antlrcpp::Any visitSlice(CuMatParser::SliceContext* ctx) override;
 
     antlrcpp::Any visitExpression(CuMatParser::ExpressionContext* ctx) override;
     antlrcpp::Any visitExp_if(CuMatParser::Exp_ifContext* ctx) override;

--- a/src/parser/inc/VariableNode.hpp
+++ b/src/parser/inc/VariableNode.hpp
@@ -4,6 +4,7 @@
 
 namespace AST {
 class VariableNode : public ExprNode {
+   public:
     std::string name;
 };
 }  // namespace AST


### PR DESCRIPTION
This should be what's needed, suggested changes for future stuff:

lval of assignmentNode could benefit from being some form of "Decomposition" node instead of a variableNode (As it can't be a variable node, due to the grammar and expressions etc.)

No support for slicing yet, not sure how we want to include that. But the code is ready to include it when you want it. 